### PR TITLE
Minor improvements to the Embedder

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ class TransformersEmbedder(torch.nn.Module):
         model: Union[str, tr.PreTrainedModel],
         return_words: bool = True,
         pooling_strategy: str = "last",
-        output_layers: List[int] = [-4, -3, -2, -1],
+        output_layers: Tuple[int] = (-4, -3, -2, -1),
         fine_tune: bool = True,
         return_all: bool = False,
     )

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ outputs = model(**inputs)
 ```
 
 ```text
-# outputs.shape[1:-1]       # remove [CLS] and [SEP]
+# outputs.word_embeddings.shape[1:-1]       # remove [CLS] and [SEP]
 torch.Size([1, 5, 768])
 # len(example)
 5

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ There are also multiple type of outputs you can get using `output_layer` paramet
 - `last`: returns the last hidden state of the transformer model
 - `concat`: returns the concatenation of the last four hidden states of the transformer model
 - `sum`: returns the sum of the last four hidden states of the transformer model
+- `mean`: returns the average of the last four hidden states of the transformer model
 - `pooled`: returns the output of the pooling layer
 
 If you also want all the outputs from the HuggingFace model, you can set `return_all=True` to get them.

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ The `TransformersEmbedder` offer 2 ways to retrieve the embeddings:
 - `return_words=True`: computes the mean of the embeddings of the sub-tokens of each word
 - `return_words=False`: returns the raw output of the transformer model without sub-token pooling
 
-There are also multiple type of outputs you can get using `output_layer` parameter:
+There are also multiple type of outputs you can get using `pooling_strategy` parameter:
 
 - `last`: returns the last hidden state of the transformer model
-- `concat`: returns the concatenation of the last four hidden states of the transformer model
-- `sum`: returns the sum of the last four hidden states of the transformer model
-- `mean`: returns the average of the last four hidden states of the transformer model
+- `concat`: returns the concatenation of the selected `output_layers` of the transformer model
+- `sum`: returns the sum of the selected `output_layers` of the transformer model
+- `mean`: returns the average of the selected `output_layers` of the transformer model
 - `pooled`: returns the output of the pooling layer
 
 If you also want all the outputs from the HuggingFace model, you can set `return_all=True` to get them.
@@ -91,7 +91,8 @@ class TransformersEmbedder(torch.nn.Module):
         self,
         model: Union[str, tr.PreTrainedModel],
         return_words: bool = True,
-        output_layer: str = "last",
+        pooling_strategy: str = "last",
+        output_layers: List[int] = [-4, -3, -2, -1],
         fine_tune: bool = True,
         return_all: bool = False,
     )

--- a/transformers_embedder/embedder.py
+++ b/transformers_embedder/embedder.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union, Tuple, List
+from typing import Optional, Union, Tuple
 
 import transformers as tr
 
@@ -39,7 +39,7 @@ class TransformersEmbedder(torch.nn.Module):
             What output to get from the transformer model. The last hidden state (``last``),
             the concatenation of the last four hidden layers (``concat``), the sum of the last four hidden
             layers (``sum``), the average of the last four hidden layers (``mean``), the pooled output (``pooled``).
-        output_layers (:obj:`list`, optional, defaults to :obj:`[-4, -3, -2, -1]`):
+        output_layers (:obj:`tuple`, optional, defaults to :obj:`(-4, -3, -2, -1)`):
             Which hidden layers to get from the transformer model.
         fine_tune (:obj:`bool`, optional, defaults to :obj:`True`):
             If ``True``, the transformer model is fine-tuned during training.
@@ -52,7 +52,7 @@ class TransformersEmbedder(torch.nn.Module):
         model: Union[str, tr.PreTrainedModel],
         return_words: bool = True,
         pooling_strategy: str = "last",
-        output_layers: List[int] = [-4, -3, -2, -1],
+        output_layers: Tuple[int] = (-4, -3, -2, -1),
         fine_tune: bool = True,
         return_all: bool = False,
     ) -> None:

--- a/transformers_embedder/embedder.py
+++ b/transformers_embedder/embedder.py
@@ -23,10 +23,6 @@ class TransformersEmbedderOutput(tr.file_utils.ModelOutput):
     hidden_states: Optional[Tuple["torch.FloatTensor"]] = None
     attentions: Optional[Tuple["torch.FloatTensor"]] = None
 
-    @property
-    def shape(self) -> Tuple[int]:
-        return self.word_embeddings.shape
-
 
 class TransformersEmbedder(torch.nn.Module):
     """

--- a/transformers_embedder/embedder.py
+++ b/transformers_embedder/embedder.py
@@ -38,7 +38,7 @@ class TransformersEmbedder(torch.nn.Module):
         output_layer (:obj:`str`, optional, defaults to :obj:`last`):
             What output to get from the transformer model. The last hidden state (``last``),
             the concatenation of the last four hidden layers (``concat``), the sum of the last four hidden
-            layers (``sum``), the pooled output (``pooled``).
+            layers (``sum``), the average of the last four hidden layers (``mean``), the pooled output (``pooled``).
         fine_tune (:obj:`bool`, optional, defaults to :obj:`True`):
             If ``True``, the transformer model is fine-tuned during training.
         return_all (:obj:`bool`, optional, defaults to :obj:`False`):
@@ -111,6 +111,9 @@ class TransformersEmbedder(torch.nn.Module):
         elif self.output_layer == "sum":
             word_embeddings = transformer_outputs.hidden_states[-4:]
             word_embeddings = torch.stack(word_embeddings, dim=0).sum(dim=0)
+        elif self.output_layer == "mean":
+            word_embeddings = transformer_outputs.hidden_states[-4:]
+            word_embeddings = torch.stack(word_embeddings, dim=0).mean(dim=0, dtype=torch.float)
         elif self.output_layer == "pooled":
             word_embeddings = transformer_outputs.pooler_output
         else:

--- a/transformers_embedder/embedder.py
+++ b/transformers_embedder/embedder.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union, Tuple
+from typing import Optional, Union, Tuple, List
 
 import transformers as tr
 
@@ -27,6 +27,7 @@ class TransformersEmbedderOutput(tr.file_utils.ModelOutput):
     def shape(self) -> Tuple[int]:
         return self.word_embeddings.shape
 
+
 class TransformersEmbedder(torch.nn.Module):
     """
     Transformer Embedder class.
@@ -38,10 +39,12 @@ class TransformersEmbedder(torch.nn.Module):
         return_words (:obj:`bool`, optional, defaults to :obj:`True`):
             If ``True`` it returns the word-level embeddings by computing the mean of the
             sub-words embeddings.
-        output_layer (:obj:`str`, optional, defaults to :obj:`last`):
+        pooling_strategy (:obj:`str`, optional, defaults to :obj:`last`):
             What output to get from the transformer model. The last hidden state (``last``),
             the concatenation of the last four hidden layers (``concat``), the sum of the last four hidden
             layers (``sum``), the average of the last four hidden layers (``mean``), the pooled output (``pooled``).
+        output_layers (:obj:`list`, optional, defaults to :obj:`[-4, -3, -2, -1]`):
+            Which hidden layers to get from the transformer model.
         fine_tune (:obj:`bool`, optional, defaults to :obj:`True`):
             If ``True``, the transformer model is fine-tuned during training.
         return_all (:obj:`bool`, optional, defaults to :obj:`False`):
@@ -52,7 +55,8 @@ class TransformersEmbedder(torch.nn.Module):
         self,
         model: Union[str, tr.PreTrainedModel],
         return_words: bool = True,
-        output_layer: str = "last",
+        pooling_strategy: str = "last",
+        output_layers: List[int] = [-4, -3, -2, -1],
         fine_tune: bool = True,
         return_all: bool = False,
     ) -> None:
@@ -63,7 +67,13 @@ class TransformersEmbedder(torch.nn.Module):
         else:
             self.transformer_model = model
         self.return_words = return_words
-        self.output_layer = output_layer
+        self.pooling_strategy = pooling_strategy
+        if max(map(abs, output_layers)) >= self.transformer_model.config.num_hidden_layers:
+            raise ValueError(
+                f"output_layers parameter not valid, choose between 0 and {self.transformer_model.config.num_hidden_layers - 1}. "
+                f"Current value `{output_layers}`"
+            )
+        self.output_layers = output_layers
         self.return_all = return_all
         if not fine_tune:
             for param in self.transformer_model.parameters():
@@ -106,23 +116,23 @@ class TransformersEmbedder(torch.nn.Module):
 
         # Shape: [batch_size, num_subtoken, embedding_size].
         transformer_outputs = self.transformer_model(**inputs)
-        if self.output_layer == "last":
+        if self.pooling_strategy == "last":
             word_embeddings = transformer_outputs.last_hidden_state
-        elif self.output_layer == "concat":
-            word_embeddings = transformer_outputs.hidden_states[-4:]
+        elif self.pooling_strategy == "concat":
+            word_embeddings = [transformer_outputs.hidden_states[layer] for layer in self.output_layers]
             word_embeddings = torch.cat(word_embeddings, dim=-1)
-        elif self.output_layer == "sum":
-            word_embeddings = transformer_outputs.hidden_states[-4:]
+        elif self.pooling_strategy == "sum":
+            word_embeddings = [transformer_outputs.hidden_states[layer] for layer in self.output_layers]
             word_embeddings = torch.stack(word_embeddings, dim=0).sum(dim=0)
-        elif self.output_layer == "mean":
-            word_embeddings = transformer_outputs.hidden_states[-4:]
+        elif self.pooling_strategy == "mean":
+            word_embeddings = [transformer_outputs.hidden_states[layer] for layer in self.output_layers]
             word_embeddings = torch.stack(word_embeddings, dim=0).mean(dim=0, dtype=torch.float)
-        elif self.output_layer == "pooled":
+        elif self.pooling_strategy == "pooled":
             word_embeddings = transformer_outputs.pooler_output
         else:
             raise ValueError(
-                "output_layer parameter not valid, choose between `last`, `concat`, "
-                f"`sum`, `pooled`. Current value `{self.output_layer}`"
+                "pooling_strategy parameter not valid, choose between `last`, `concat`, "
+                f"`sum`, `pooled`. Current value `{self.pooling_strategy}`"
             )
 
         if self.return_words and offsets is None:
@@ -255,5 +265,5 @@ class TransformersEmbedder(torch.nn.Module):
             :obj:`int`: Hidden size of ``self.transformer_model``.
 
         """
-        multiplier = 4 if self.output_layer == "concat" else 1
+        multiplier = len(self.output_layers) if self.pooling_strategy == "concat" else 1
         return self.transformer_model.config.hidden_size * multiplier

--- a/transformers_embedder/embedder.py
+++ b/transformers_embedder/embedder.py
@@ -23,6 +23,9 @@ class TransformersEmbedderOutput(tr.file_utils.ModelOutput):
     hidden_states: Optional[Tuple["torch.FloatTensor"]] = None
     attentions: Optional[Tuple["torch.FloatTensor"]] = None
 
+    @property
+    def shape(self) -> Tuple[int]:
+        return self.word_embeddings.shape
 
 class TransformersEmbedder(torch.nn.Module):
     """

--- a/transformers_embedder/utils.py
+++ b/transformers_embedder/utils.py
@@ -6,16 +6,12 @@ _spacy_available = importlib.util.find_spec("spacy") is not None
 
 
 def is_torch_available():
-    """
-    Check if PyTorch is available.
-    """
+    """Check if PyTorch is available."""
     return _torch_available
 
 
 def is_spacy_available():
-    """
-    Check if spaCy is available.
-    """
+    """Check if spaCy is available."""
     return _spacy_available
 
 


### PR DESCRIPTION
The following changes have been applied:
- Add support to average the last four hidden layers of the transformer model
- ~~Add a `shape` property to the `TransformersEmbedderOutput` class (referenced in the `README`)~~
- Add option to specify which hidden states to use for pooling
- Update the docs accordingly
- Run black in compliance with the project specifications
- Fix documentation issues