### PR TITLE
Feature/sparse pooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # custom
+stuff
 /test.ipynb
 /test.py
 
@@ -316,3 +317,4 @@ $RECYCLE.BIN/
 
 # End of https://www.toptal.com/developers/gitignore/api/python,pycharm+all,vscode,macos,linux,windows
 
+/stuff/

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,2 @@
 pre-commit
+datasets

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = ["transformers>=4.3,<4.18"]
 
 setuptools.setup(
     name="transformers_embedder",  # Replace with your own username
-    version="2.0.1",
+    version="2.0.2",
     author="Riccardo Orlando",
     author_email="orlandoricc@gmail.com",
     description="Word level transformer based embeddings",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = ["transformers>=4.3,<4.18"]
 
 setuptools.setup(
     name="transformers_embedder",  # Replace with your own username
-    version="2.0.0",
+    version="2.0.1",
     author="Riccardo Orlando",
     author_email="orlandoricc@gmail.com",
     description="Word level transformer based embeddings",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = ["transformers>=4.3,<4.18"]
 
 setuptools.setup(
     name="transformers_embedder",  # Replace with your own username
-    version="2.0.0b2",
+    version="2.0.0",
     author="Riccardo Orlando",
     author_email="orlandoricc@gmail.com",
     description="Word level transformer based embeddings",

--- a/transformers_embedder/benchmark.py
+++ b/transformers_embedder/benchmark.py
@@ -1,0 +1,72 @@
+import itertools
+import random
+import time
+
+import numpy as np
+import torch
+from datasets import load_dataset
+from torch.types import Device
+from torch.utils.data import DataLoader
+
+import transformers_embedder as tre
+
+torch.set_grad_enabled(False)
+
+seed: int = 42
+transformer_name: str = "bert-base-cased"
+device: Device = "cuda"
+
+# seed_everything by PyTorch Lightning
+random.seed(seed)
+np.random.seed(seed)
+torch.manual_seed(seed)
+torch.cuda.manual_seed_all(seed)
+
+
+tokenizer = tre.Tokenizer(transformer_name)
+
+dataset = load_dataset("Babelscape/wikineural", split="test_en")
+batch_size = 160
+n_batches = 50
+
+dataloader = DataLoader(
+    dataset=dataset,
+    shuffle=True,
+    batch_size=batch_size,
+    pin_memory=True,
+    collate_fn=lambda samples: tokenizer(
+        [sample["tokens"] for sample in samples],
+        padding=True,
+        return_tensors=True,
+        is_split_into_words=True,
+        compute_bpe_info=True,
+    ),
+)
+iter_dataloader = iter(dataloader)
+
+batches = [next(iter_dataloader).to(device) for _ in range(n_batches)]
+
+pooling2model = {
+    pooling_strategy: tre.TransformersEmbedder(
+        transformer_name,
+        return_words=True,
+        layer_pooling_strategy="mean",
+        subword_pooling_strategy=pooling_strategy,
+    )
+    .to(device)
+    .eval()
+    for pooling_strategy in ("scatter", "sparse", "inefficient")
+}
+
+pooling2output = {pooling: model(**batches[0]) for pooling, model in pooling2model.items()}
+atol = 1e-7
+for (pool1, out1), (pool2, out2) in itertools.combinations(pooling2output.items(), r=2):
+    all_close = torch.allclose(out1.word_embeddings, out2.word_embeddings, atol=atol)
+    print(f"{pool1} == {pool2} (allclose with {atol=}): {all_close}")
+
+for pooling, model in pooling2model.items():
+    start = time.time()
+    for batch in batches:
+        model(**batch)
+    end = time.time()
+    print(pooling, (end - start))

--- a/transformers_embedder/embedder.py
+++ b/transformers_embedder/embedder.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union, Tuple, Sequence
+from typing import Optional, Union, Tuple, Sequence, Any, Mapping
 
 import transformers as tr
+from torch.nn.utils.rnn import pad_sequence
 
 from transformers_embedder import utils
 
@@ -53,6 +54,7 @@ class TransformersEmbedder(torch.nn.Module):
         model: Union[str, tr.PreTrainedModel],
         return_words: bool = True,
         layer_pooling_strategy: str = "last",
+        subword_pooling_strategy: str = "scatter",
         output_layers: Sequence[int] = (-4, -3, -2, -1),
         fine_tune: bool = True,
         return_all: bool = False,
@@ -69,6 +71,7 @@ class TransformersEmbedder(torch.nn.Module):
             self.transformer_model = model
         self.return_words = return_words
         self.pooling_strategy = layer_pooling_strategy
+        self.merge_strategy = subword_pooling_strategy
         if max(map(abs, output_layers)) >= self.transformer_model.config.num_hidden_layers:
             raise ValueError(
                 f"`output_layers` parameter not valid, choose between 0 and "
@@ -87,6 +90,7 @@ class TransformersEmbedder(torch.nn.Module):
         attention_mask: Optional[torch.Tensor] = None,
         token_type_ids: Optional[torch.Tensor] = None,
         offsets: Optional[torch.Tensor] = None,
+        bpe_info: Optional[Mapping[str, Any]] = None,
         *args,
         **kwargs,
     ) -> TransformersEmbedderOutput:
@@ -141,7 +145,17 @@ class TransformersEmbedder(torch.nn.Module):
             )
         if self.return_words:
             # Shape: [batch_size, num_words, embedding_size].
-            word_embeddings = self.merge_subword(word_embeddings, offsets)
+            if self.merge_strategy == "scatter":
+                word_embeddings = self.merge_subword(word_embeddings, indices=offsets)
+            elif self.merge_strategy == "sparse":
+                word_embeddings = self.merge_sparse(word_embeddings, bpe_info)
+            elif self.merge_strategy == "inefficient":
+                word_embeddings = self.merge_inefficient(word_embeddings, bpe_info)
+            else:
+                raise ValueError(
+                    "`merge_strategy` parameter not valid, choose between `scatter`, `sparse`, `inefficient`."
+                    f"Current value `{self.merge_strategy}`"
+                )
         if self.return_all:
             return TransformersEmbedderOutput(
                 word_embeddings=word_embeddings,
@@ -177,6 +191,29 @@ class TransformersEmbedder(torch.nn.Module):
         count = self.broadcast(count, out)
         out.true_divide_(count)
         return out
+
+    def merge_sparse(self, embeddings: torch.Tensor, bpe_info: Optional[Mapping[str, Any]]) -> torch.Tensor:
+        # it is constructed here and not in the tokenizer/collate because pin_memory is not sparse-compatible
+        bpe_weights = torch.sparse_coo_tensor(
+            indices=bpe_info["sparse_indices"],
+            values=bpe_info["sparse_values"],
+            size=bpe_info["sparse_size"],
+        )
+
+        # (sentence, word, bpe) x (sentence, bpe, transformer_dim) -> (sentence, word, transformer_dim)
+        return torch.bmm(bpe_weights, embeddings)
+
+    def merge_inefficient(self, embeddings: torch.Tensor, bpe_info: Optional[Mapping[str, Any]]):
+        out = []
+        for i_sentence in range(embeddings.shape[0]):
+            i = 0
+            sentence_emb = []
+            for word_length in bpe_info["sentence_lengths"][i_sentence]:
+                sentence_emb.append(embeddings[i_sentence, i : i + word_length, :].mean(dim=0))
+                i += word_length
+            out.append(torch.stack(sentence_emb))
+
+        return pad_sequence(out, batch_first=True)
 
     def scatter_sum(self, src: torch.Tensor, index: torch.Tensor) -> torch.Tensor:
         """

--- a/transformers_embedder/embedder.py
+++ b/transformers_embedder/embedder.py
@@ -56,11 +56,15 @@ class TransformersEmbedder(torch.nn.Module):
         output_layers: Sequence[int] = (-4, -3, -2, -1),
         fine_tune: bool = True,
         return_all: bool = False,
+        *args,
+        **kwargs,
     ) -> None:
         super().__init__()
         if isinstance(model, str):
-            config = tr.AutoConfig.from_pretrained(model, output_hidden_states=True, output_attentions=True)
-            self.transformer_model = tr.AutoModel.from_pretrained(model, config=config)
+            config = tr.AutoConfig.from_pretrained(
+                model, output_hidden_states=True, output_attentions=True, *args, **kwargs
+            )
+            self.transformer_model = tr.AutoModel.from_pretrained(model, config=config, *args, **kwargs)
         else:
             self.transformer_model = model
         self.return_words = return_words

--- a/transformers_embedder/embedder.py
+++ b/transformers_embedder/embedder.py
@@ -168,6 +168,8 @@ class TransformersEmbedder(torch.nn.Module):
         Returns:
             :obj:`torch.Tensor`
         """
+        # replace padding indices with the maximum value inside the batch
+        indices[indices == -1] = torch.max(indices)
         out = self.scatter_sum(embeddings, indices)
         ones = torch.ones(indices.size(), dtype=embeddings.dtype, device=embeddings.device)
         count = self.scatter_sum(ones, indices)

--- a/transformers_embedder/tokenizer.py
+++ b/transformers_embedder/tokenizer.py
@@ -117,6 +117,11 @@ class Tokenizer:
         # add the offsets to the model inputs
         model_inputs.update({"offsets": offsets, "sentence_lengths": sentence_lengths})
 
+        # we also update the maximum batch length,
+        # both for subword and word level
+        self.subword_max_batch_len = max(len(x) for x in model_inputs.input_ids)
+        self.word_max_batch_len = max(x for x in model_inputs.sentence_lengths)
+
         # check if we need to convert other stuff to tensors
         if additional_inputs:
             model_inputs.update(additional_inputs)
@@ -550,7 +555,7 @@ class ModelInputs(UserDict):
         try:
             return self.data[item]
         except KeyError:
-            raise AttributeError
+            raise AttributeError(f"`ModelInputs` has no attribute `{item}`")
 
     def __getitem__(self, item: str) -> Any:
         return self.data[item]

--- a/transformers_embedder/tokenizer.py
+++ b/transformers_embedder/tokenizer.py
@@ -591,9 +591,7 @@ class ModelInputs(UserDict):
             after modification.
         """
         if isinstance(device, (str, torch.device, int)):
-            self.data = {
-                k: v.to(device=device) if isinstance(v, torch.Tensor) else v for k, v in self.data.items()
-            }
+            self.data = {k: v.to(device=device) if hasattr(v, "to") else v for k, v in self.data.items()}
         else:
             logger.warning(f"Attempting to cast to another type, {str(device)}. This is not supported.")
         return self

--- a/transformers_embedder/utils.py
+++ b/transformers_embedder/utils.py
@@ -2,22 +2,11 @@ import importlib.util
 import logging
 
 _torch_available = importlib.util.find_spec("torch") is not None
-_spacy_available = importlib.util.find_spec("spacy") is not None
 
 
 def is_torch_available():
     """Check if PyTorch is available."""
     return _torch_available
-
-
-def is_spacy_available():
-    """Check if spaCy is available."""
-    return _spacy_available
-
-
-if is_torch_available():
-    import torch
-    from torch import Tensor
 
 
 def get_logger(name: str) -> logging.Logger:


### PR DESCRIPTION
This PR adds a new pooling method for subwords (well, two, but the `inefficient` one is there only for benchmarking purposes).
The `sparse` one is necessary for contexts where we want to enable CUDA determinism since scatter methods do not support it.

The script benchmark.py compares them, but I think that there is some mismatch in the approaches since these are the results (GPU: NVIDIA 2060S | CPU: AMD 3700X):
```
scatter == sparse (allclose with atol=1e-07): False
scatter == inefficient (allclose with atol=1e-07): False
sparse == inefficient (allclose with atol=1e-07): True
scatter 23.960102558135986s
sparse 23.518492221832275s
inefficient 24.366436004638672s
```

I wrote the "inefficient" pooling method as a control one, and it seems like the scatter method is not matching its results. 
I think the mismatch can be traced to something weird happening with the padded positions, but I didn't investigate further.

I could very well have implemented both the control and the sparse methods wrongly, so please double-check everything!

And thank you for the library, it is truly useful!

